### PR TITLE
Order output according to project name list

### DIFF
--- a/project_order.txt
+++ b/project_order.txt
@@ -1,0 +1,30 @@
+Fri musik på Wikipedia 2019
+Stöd för innehållspartnerskap 2021
+Wikipedia i utbildning 2021
+Samsyn 2018
+Strategisk inkludering av biblioteksdata på Wikidata 2021
+Wikipedia i biblioteken 2021
+GLAM 2021
+Wikidata för auktoritetskontroll 2021
+Föreläsningar 2021
+Verktyg för innehållspartners 2021
+Påverkansarbete 2021
+Wikispeech – Talresursinsamlaren 2019
+Wikispeech för AI 2020
+Förtroende 2021
+Synlighet 2021
+Wikidata för genealogi 2021
+Buggrapportering och översättning 2021
+Kunskap i krissituationer 2021
+Wikispeech – Underhåll och support 2021
+Stöd till gemenskapen 2021
+Utvecklingsstöd 2021
+Wiki Loves 2021
+En gemenskap för alla 2021
+Partnerskap för WikiGap 2021
+Sänkta trösklar för WikiGap 2021
+Verktyg för partnerskap 2020
+Organisationsutveckling 2021
+Erfarenhetsutbyte 2021
+Föreningsengagemang 2021
+FOSS för föreningen 2021


### PR DESCRIPTION
Added an optional parameter for supplying a list of projects. The
output will have the same order as this list. This makes it easier to
just copy paste all projects in one go. Added such a file with the
current order in the target document.

Also add dates on output rather than storing them in the data.