### PR TITLE
Bump pywikibot version to one which works well with pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pywikibot==3.0.20190722
+pywikibot==3.0.20200111
 mwparserfromhell


### PR DESCRIPTION
The currently pinned pywikibot version has installation issues since
it's internal version marking conflicts with that of the release.

This bumps it to the next one where that issue has been fixed.